### PR TITLE
Apply spotless license headers and formatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Initial application of Spotless licence headers and formatting
+38931ce3ecf58436c616cc03f0675c295dd05597

--- a/src/main/java/com/opencastsoftware/yvette/Arithmetic.java
+++ b/src/main/java/com/opencastsoftware/yvette/Arithmetic.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
 public class Arithmetic {

--- a/src/main/java/com/opencastsoftware/yvette/BasicDiagnostic.java
+++ b/src/main/java/com/opencastsoftware/yvette/BasicDiagnostic.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
 import java.net.URI;

--- a/src/main/java/com/opencastsoftware/yvette/Diagnostic.java
+++ b/src/main/java/com/opencastsoftware/yvette/Diagnostic.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
 import java.net.URI;

--- a/src/main/java/com/opencastsoftware/yvette/LabelledRange.java
+++ b/src/main/java/com/opencastsoftware/yvette/LabelledRange.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
 public class LabelledRange extends Range {

--- a/src/main/java/com/opencastsoftware/yvette/Line.java
+++ b/src/main/java/com/opencastsoftware/yvette/Line.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
 public class Line {

--- a/src/main/java/com/opencastsoftware/yvette/LinkStyle.java
+++ b/src/main/java/com/opencastsoftware/yvette/LinkStyle.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
 public enum LinkStyle {

--- a/src/main/java/com/opencastsoftware/yvette/Position.java
+++ b/src/main/java/com/opencastsoftware/yvette/Position.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
 public class Position implements Comparable<Position> {

--- a/src/main/java/com/opencastsoftware/yvette/Range.java
+++ b/src/main/java/com/opencastsoftware/yvette/Range.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
 public class Range {

--- a/src/main/java/com/opencastsoftware/yvette/RangeContents.java
+++ b/src/main/java/com/opencastsoftware/yvette/RangeContents.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
 import java.util.List;

--- a/src/main/java/com/opencastsoftware/yvette/Severity.java
+++ b/src/main/java/com/opencastsoftware/yvette/Severity.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
 /*

--- a/src/main/java/com/opencastsoftware/yvette/SourceCode.java
+++ b/src/main/java/com/opencastsoftware/yvette/SourceCode.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
 import java.io.IOException;

--- a/src/main/java/com/opencastsoftware/yvette/StringRangeContents.java
+++ b/src/main/java/com/opencastsoftware/yvette/StringRangeContents.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
 import java.util.List;

--- a/src/main/java/com/opencastsoftware/yvette/StringSourceCode.java
+++ b/src/main/java/com/opencastsoftware/yvette/StringSourceCode.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
 import java.util.Arrays;

--- a/src/main/java/com/opencastsoftware/yvette/TextWrap.java
+++ b/src/main/java/com/opencastsoftware/yvette/TextWrap.java
@@ -1,9 +1,13 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
+
+import org.apache.commons.text.WordUtils;
 
 import java.io.IOException;
 import java.util.regex.Pattern;
-
-import org.apache.commons.text.WordUtils;
 
 public class TextWrap {
     private TextWrap() {

--- a/src/main/java/com/opencastsoftware/yvette/URIRangeContents.java
+++ b/src/main/java/com/opencastsoftware/yvette/URIRangeContents.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
 import java.net.URI;

--- a/src/main/java/com/opencastsoftware/yvette/URISourceCode.java
+++ b/src/main/java/com/opencastsoftware/yvette/URISourceCode.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
 import java.io.IOException;

--- a/src/main/java/com/opencastsoftware/yvette/UncaughtExceptionHandler.java
+++ b/src/main/java/com/opencastsoftware/yvette/UncaughtExceptionHandler.java
@@ -1,9 +1,13 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
+
+import com.opencastsoftware.yvette.handlers.ReportHandler;
 
 import java.io.IOException;
 import java.io.PrintStream;
-
-import com.opencastsoftware.yvette.handlers.ReportHandler;
 
 public class UncaughtExceptionHandler {
     private static volatile Thread.UncaughtExceptionHandler previous;

--- a/src/main/java/com/opencastsoftware/yvette/handlers/ReportHandler.java
+++ b/src/main/java/com/opencastsoftware/yvette/handlers/ReportHandler.java
@@ -1,8 +1,12 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers;
 
-import java.io.IOException;
-
 import com.opencastsoftware.yvette.Diagnostic;
+
+import java.io.IOException;
 
 public interface ReportHandler {
     void display(Diagnostic diagnostic, Appendable output) throws IOException;

--- a/src/main/java/com/opencastsoftware/yvette/handlers/ToStringReportHandler.java
+++ b/src/main/java/com/opencastsoftware/yvette/handlers/ToStringReportHandler.java
@@ -1,8 +1,12 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers;
 
-import java.io.IOException;
-
 import com.opencastsoftware.yvette.Diagnostic;
+
+import java.io.IOException;
 
 public final class ToStringReportHandler implements ReportHandler {
     @Override

--- a/src/main/java/com/opencastsoftware/yvette/handlers/graphical/AnsiThemeStyles.java
+++ b/src/main/java/com/opencastsoftware/yvette/handlers/graphical/AnsiThemeStyles.java
@@ -1,11 +1,15 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
+
+import org.fusesource.jansi.Ansi;
 
 import java.util.Collection;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import org.fusesource.jansi.Ansi;
 
 public final class AnsiThemeStyles implements ThemeStyles {
     @Override

--- a/src/main/java/com/opencastsoftware/yvette/handlers/graphical/AsciiThemeCharacters.java
+++ b/src/main/java/com/opencastsoftware/yvette/handlers/graphical/AsciiThemeCharacters.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
 
 public final class AsciiThemeCharacters implements ThemeCharacters {

--- a/src/main/java/com/opencastsoftware/yvette/handlers/graphical/ColourSupport.java
+++ b/src/main/java/com/opencastsoftware/yvette/handlers/graphical/ColourSupport.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
 
 public enum ColourSupport {

--- a/src/main/java/com/opencastsoftware/yvette/handlers/graphical/EmojiThemeCharacters.java
+++ b/src/main/java/com/opencastsoftware/yvette/handlers/graphical/EmojiThemeCharacters.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
 
 public final class EmojiThemeCharacters implements ThemeCharacters {

--- a/src/main/java/com/opencastsoftware/yvette/handlers/graphical/GraphicalReportHandler.java
+++ b/src/main/java/com/opencastsoftware/yvette/handlers/graphical/GraphicalReportHandler.java
@@ -1,4 +1,15 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
+
+import com.opencastsoftware.yvette.*;
+import com.opencastsoftware.yvette.handlers.ReportHandler;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.function.Failable;
+import org.fusesource.jansi.Ansi;
 
 import java.io.IOException;
 import java.util.*;
@@ -10,14 +21,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-
-import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.function.Failable;
-import org.fusesource.jansi.Ansi;
-
-import com.opencastsoftware.yvette.*;
-import com.opencastsoftware.yvette.handlers.ReportHandler;
 
 public class GraphicalReportHandler implements ReportHandler {
     private final LinkStyle linkStyle;

--- a/src/main/java/com/opencastsoftware/yvette/handlers/graphical/GraphicalTheme.java
+++ b/src/main/java/com/opencastsoftware/yvette/handlers/graphical/GraphicalTheme.java
@@ -1,8 +1,12 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
 
-import java.util.function.UnaryOperator;
-
 import org.fusesource.jansi.Ansi;
+
+import java.util.function.UnaryOperator;
 
 public class GraphicalTheme {
     private final ThemeCharacters characters;

--- a/src/main/java/com/opencastsoftware/yvette/handlers/graphical/NoThemeStyles.java
+++ b/src/main/java/com/opencastsoftware/yvette/handlers/graphical/NoThemeStyles.java
@@ -1,11 +1,15 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
+
+import org.fusesource.jansi.Ansi;
 
 import java.util.Collection;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import org.fusesource.jansi.Ansi;
 
 public final class NoThemeStyles implements ThemeStyles {
 

--- a/src/main/java/com/opencastsoftware/yvette/handlers/graphical/RgbColours.java
+++ b/src/main/java/com/opencastsoftware/yvette/handlers/graphical/RgbColours.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
 
 public enum RgbColours {

--- a/src/main/java/com/opencastsoftware/yvette/handlers/graphical/RgbThemeStyles.java
+++ b/src/main/java/com/opencastsoftware/yvette/handlers/graphical/RgbThemeStyles.java
@@ -1,11 +1,15 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
+
+import org.fusesource.jansi.Ansi;
 
 import java.util.Collection;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import org.fusesource.jansi.Ansi;
 
 public final class RgbThemeStyles implements ThemeStyles {
 

--- a/src/main/java/com/opencastsoftware/yvette/handlers/graphical/StyledRange.java
+++ b/src/main/java/com/opencastsoftware/yvette/handlers/graphical/StyledRange.java
@@ -1,12 +1,15 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
-
-import java.util.function.UnaryOperator;
-
-import org.fusesource.jansi.Ansi;
 
 import com.opencastsoftware.yvette.LabelledRange;
 import com.opencastsoftware.yvette.Line;
 import com.opencastsoftware.yvette.Position;
+import org.fusesource.jansi.Ansi;
+
+import java.util.function.UnaryOperator;
 
 public class StyledRange extends LabelledRange {
     private final UnaryOperator<Ansi> style;

--- a/src/main/java/com/opencastsoftware/yvette/handlers/graphical/TerminalSupport.java
+++ b/src/main/java/com/opencastsoftware/yvette/handlers/graphical/TerminalSupport.java
@@ -1,13 +1,17 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
-
-import java.io.PrintStream;
-import java.util.Arrays;
-import java.util.function.Predicate;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.fusesource.jansi.AnsiConsole;
 import org.fusesource.jansi.internal.CLibrary;
+
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.function.Predicate;
 
 class TerminalSupport {
     public static boolean isAtty(Appendable output) {

--- a/src/main/java/com/opencastsoftware/yvette/handlers/graphical/ThemeCharacters.java
+++ b/src/main/java/com/opencastsoftware/yvette/handlers/graphical/ThemeCharacters.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
 
 import com.opencastsoftware.yvette.Severity;

--- a/src/main/java/com/opencastsoftware/yvette/handlers/graphical/ThemeStyles.java
+++ b/src/main/java/com/opencastsoftware/yvette/handlers/graphical/ThemeStyles.java
@@ -1,11 +1,14 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
+
+import com.opencastsoftware.yvette.Severity;
+import org.fusesource.jansi.Ansi;
 
 import java.util.Collection;
 import java.util.function.UnaryOperator;
-
-import org.fusesource.jansi.Ansi;
-
-import com.opencastsoftware.yvette.Severity;
 
 public interface ThemeStyles {
     UnaryOperator<Ansi> error();

--- a/src/main/java/com/opencastsoftware/yvette/handlers/graphical/UnicodeThemeCharacters.java
+++ b/src/main/java/com/opencastsoftware/yvette/handlers/graphical/UnicodeThemeCharacters.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
 
 public final class UnicodeThemeCharacters implements ThemeCharacters {

--- a/src/test/java/com/opencastsoftware/yvette/LabelledRangeTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/LabelledRangeTest.java
@@ -1,11 +1,13 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
-
-import org.junit.jupiter.api.Test;
 
 import com.jparams.verifier.tostring.ToStringVerifier;
 import com.opencastsoftware.yvette.handlers.graphical.StyledRange;
-
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
 
 public class LabelledRangeTest {
     @Test

--- a/src/test/java/com/opencastsoftware/yvette/LineTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/LineTest.java
@@ -1,10 +1,12 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
-import org.junit.jupiter.api.Test;
-
 import com.jparams.verifier.tostring.ToStringVerifier;
-
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
 
 public class LineTest {
     @Test

--- a/src/test/java/com/opencastsoftware/yvette/PositionTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/PositionTest.java
@@ -1,10 +1,12 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
-import org.junit.jupiter.api.Test;
-
 import com.jparams.verifier.tostring.ToStringVerifier;
-
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
 
 public class PositionTest {
     @Test

--- a/src/test/java/com/opencastsoftware/yvette/RangeTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/RangeTest.java
@@ -1,10 +1,12 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
-import org.junit.jupiter.api.Test;
-
 import com.jparams.verifier.tostring.ToStringVerifier;
-
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
 
 public class RangeTest {
     @Test

--- a/src/test/java/com/opencastsoftware/yvette/StringRangeContentsTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/StringRangeContentsTest.java
@@ -1,10 +1,12 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
-import org.junit.jupiter.api.Test;
-
 import com.jparams.verifier.tostring.ToStringVerifier;
-
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
 
 public class StringRangeContentsTest {
     @Test

--- a/src/test/java/com/opencastsoftware/yvette/StringSourceCodeTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/StringSourceCodeTest.java
@@ -1,13 +1,15 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
+
+import com.jparams.verifier.tostring.ToStringVerifier;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-
-import org.junit.jupiter.api.Test;
-
-import com.jparams.verifier.tostring.ToStringVerifier;
-
-import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class StringSourceCodeTest {
     private static final String TEST_SOURCE = String.join(

--- a/src/test/java/com/opencastsoftware/yvette/TestDiagnostic.java
+++ b/src/test/java/com/opencastsoftware/yvette/TestDiagnostic.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
 import java.net.URI;

--- a/src/test/java/com/opencastsoftware/yvette/TextWrapTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/TextWrapTest.java
@@ -1,11 +1,15 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-
-import java.io.IOException;
 
 public class TextWrapTest {
     @Test

--- a/src/test/java/com/opencastsoftware/yvette/URIRangeContentsTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/URIRangeContentsTest.java
@@ -1,10 +1,12 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
-import org.junit.jupiter.api.Test;
-
 import com.jparams.verifier.tostring.ToStringVerifier;
-
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
 
 public class URIRangeContentsTest {
     @Test

--- a/src/test/java/com/opencastsoftware/yvette/URISourceCodeTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/URISourceCodeTest.java
@@ -1,18 +1,20 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import com.jparams.verifier.tostring.ToStringVerifier;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Objects;
 
-import org.junit.jupiter.api.Test;
-
-import com.jparams.verifier.tostring.ToStringVerifier;
-
-import nl.jqno.equalsverifier.EqualsVerifier;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 public class URISourceCodeTest {
     private static URI testSourceFile;

--- a/src/test/java/com/opencastsoftware/yvette/UncaughtExceptionHandlerTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/UncaughtExceptionHandlerTest.java
@@ -1,17 +1,20 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import com.opencastsoftware.yvette.handlers.ReportHandler;
+import com.opencastsoftware.yvette.handlers.graphical.GraphicalReportHandler;
+import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.AccessDeniedException;
 import java.util.concurrent.*;
 
-import org.junit.jupiter.api.Test;
-
-import com.opencastsoftware.yvette.handlers.ReportHandler;
-import com.opencastsoftware.yvette.handlers.graphical.GraphicalReportHandler;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 public class UncaughtExceptionHandlerTest {
 

--- a/src/test/java/com/opencastsoftware/yvette/arbitrary/CodesSupplier.java
+++ b/src/test/java/com/opencastsoftware/yvette/arbitrary/CodesSupplier.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.arbitrary;
 
 import net.jqwik.api.Arbitraries;

--- a/src/test/java/com/opencastsoftware/yvette/arbitrary/DiagnosticSupplier.java
+++ b/src/test/java/com/opencastsoftware/yvette/arbitrary/DiagnosticSupplier.java
@@ -1,14 +1,17 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.arbitrary;
 
-import java.util.Collections;
-import java.util.List;
-
 import com.opencastsoftware.yvette.*;
-
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.ArbitrarySupplier;
 import net.jqwik.api.Combinators;
+
+import java.util.Collections;
+import java.util.List;
 
 public class DiagnosticSupplier implements ArbitrarySupplier<Diagnostic> {
     @Override

--- a/src/test/java/com/opencastsoftware/yvette/arbitrary/GraphicalThemeSupplier.java
+++ b/src/test/java/com/opencastsoftware/yvette/arbitrary/GraphicalThemeSupplier.java
@@ -1,9 +1,12 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.arbitrary;
 
 import com.opencastsoftware.yvette.handlers.graphical.GraphicalTheme;
 import com.opencastsoftware.yvette.handlers.graphical.ThemeCharacters;
 import com.opencastsoftware.yvette.handlers.graphical.ThemeStyles;
-
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.ArbitrarySupplier;

--- a/src/test/java/com/opencastsoftware/yvette/arbitrary/LinkStyleSupplier.java
+++ b/src/test/java/com/opencastsoftware/yvette/arbitrary/LinkStyleSupplier.java
@@ -1,7 +1,10 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.arbitrary;
 
 import com.opencastsoftware.yvette.LinkStyle;
-
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.ArbitrarySupplier;

--- a/src/test/java/com/opencastsoftware/yvette/arbitrary/SeveritySupplier.java
+++ b/src/test/java/com/opencastsoftware/yvette/arbitrary/SeveritySupplier.java
@@ -1,7 +1,10 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.arbitrary;
 
 import com.opencastsoftware.yvette.Severity;
-
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.ArbitrarySupplier;

--- a/src/test/java/com/opencastsoftware/yvette/arbitrary/StringSourceCodeSupplier.java
+++ b/src/test/java/com/opencastsoftware/yvette/arbitrary/StringSourceCodeSupplier.java
@@ -1,7 +1,10 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.arbitrary;
 
 import com.opencastsoftware.yvette.StringSourceCode;
-
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.ArbitrarySupplier;

--- a/src/test/java/com/opencastsoftware/yvette/arbitrary/URLSupplier.java
+++ b/src/test/java/com/opencastsoftware/yvette/arbitrary/URLSupplier.java
@@ -1,10 +1,14 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.arbitrary;
-
-import java.net.URI;
 
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.ArbitrarySupplier;
 import net.jqwik.web.api.Web;
+
+import java.net.URI;
 
 public class URLSupplier implements ArbitrarySupplier<URI> {
     @Override

--- a/src/test/java/com/opencastsoftware/yvette/handlers/ToStringReportHandlerTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/handlers/ToStringReportHandlerTest.java
@@ -1,20 +1,22 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-
-import java.io.IOException;
-
-import org.junit.jupiter.api.Test;
 
 import com.jparams.verifier.tostring.ToStringVerifier;
 import com.opencastsoftware.yvette.Diagnostic;
 import com.opencastsoftware.yvette.arbitrary.DiagnosticSupplier;
-
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class ToStringReportHandlerTest {
     private final ToStringReportHandler handler = new ToStringReportHandler();

--- a/src/test/java/com/opencastsoftware/yvette/handlers/graphical/AnsiThemeStylesTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/handlers/graphical/AnsiThemeStylesTest.java
@@ -1,10 +1,12 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
 
-import org.junit.jupiter.api.Test;
-
 import com.jparams.verifier.tostring.ToStringVerifier;
-
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
 
 public class AnsiThemeStylesTest {
     @Test

--- a/src/test/java/com/opencastsoftware/yvette/handlers/graphical/AsciiThemeCharactersTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/handlers/graphical/AsciiThemeCharactersTest.java
@@ -1,10 +1,12 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
 
-import org.junit.jupiter.api.Test;
-
 import com.jparams.verifier.tostring.ToStringVerifier;
-
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
 
 public class AsciiThemeCharactersTest {
     @Test

--- a/src/test/java/com/opencastsoftware/yvette/handlers/graphical/EmojiThemeCharactersTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/handlers/graphical/EmojiThemeCharactersTest.java
@@ -1,10 +1,12 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
 
-import org.junit.jupiter.api.Test;
-
 import com.jparams.verifier.tostring.ToStringVerifier;
-
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
 
 public class EmojiThemeCharactersTest {
     @Test

--- a/src/test/java/com/opencastsoftware/yvette/handlers/graphical/GraphicalReportHandlerBuilderTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/handlers/graphical/GraphicalReportHandlerBuilderTest.java
@@ -1,14 +1,16 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-
-import org.junit.jupiter.api.Test;
 
 import com.jparams.verifier.tostring.ToStringVerifier;
 import com.opencastsoftware.yvette.LinkStyle;
-
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 public class GraphicalReportHandlerBuilderTest {
 

--- a/src/test/java/com/opencastsoftware/yvette/handlers/graphical/GraphicalReportHandlerTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/handlers/graphical/GraphicalReportHandlerTest.java
@@ -1,8 +1,20 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import com.jparams.verifier.tostring.ToStringVerifier;
+import com.opencastsoftware.yvette.*;
+import com.opencastsoftware.yvette.arbitrary.DiagnosticSupplier;
+import com.opencastsoftware.yvette.arbitrary.GraphicalThemeSupplier;
+import com.opencastsoftware.yvette.arbitrary.LinkStyleSupplier;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.IntRange;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -11,19 +23,9 @@ import java.nio.file.AccessDeniedException;
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-
-import com.jparams.verifier.tostring.ToStringVerifier;
-import com.opencastsoftware.yvette.*;
-import com.opencastsoftware.yvette.arbitrary.DiagnosticSupplier;
-import com.opencastsoftware.yvette.arbitrary.GraphicalThemeSupplier;
-import com.opencastsoftware.yvette.arbitrary.LinkStyleSupplier;
-
-import net.jqwik.api.ForAll;
-import net.jqwik.api.Property;
-import net.jqwik.api.constraints.IntRange;
-import nl.jqno.equalsverifier.EqualsVerifier;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GraphicalReportHandlerTest {
     private final GraphicalReportHandler handler = GraphicalReportHandler.builder()

--- a/src/test/java/com/opencastsoftware/yvette/handlers/graphical/GraphicalThemeTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/handlers/graphical/GraphicalThemeTest.java
@@ -1,10 +1,12 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
 
-import org.junit.jupiter.api.Test;
-
 import com.jparams.verifier.tostring.ToStringVerifier;
-
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
 
 public class GraphicalThemeTest {
     @Test

--- a/src/test/java/com/opencastsoftware/yvette/handlers/graphical/NoThemeStylesTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/handlers/graphical/NoThemeStylesTest.java
@@ -1,10 +1,12 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
 
-import org.junit.jupiter.api.Test;
-
 import com.jparams.verifier.tostring.ToStringVerifier;
-
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
 
 public class NoThemeStylesTest {
     @Test

--- a/src/test/java/com/opencastsoftware/yvette/handlers/graphical/RgbThemeStylesTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/handlers/graphical/RgbThemeStylesTest.java
@@ -1,10 +1,12 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
 
-import org.junit.jupiter.api.Test;
-
 import com.jparams.verifier.tostring.ToStringVerifier;
-
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
 
 public class RgbThemeStylesTest {
     @Test

--- a/src/test/java/com/opencastsoftware/yvette/handlers/graphical/StyledRangeTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/handlers/graphical/StyledRangeTest.java
@@ -1,10 +1,12 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
 
-import org.junit.jupiter.api.Test;
-
 import com.jparams.verifier.tostring.ToStringVerifier;
-
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
 
 public class StyledRangeTest {
     @Test

--- a/src/test/java/com/opencastsoftware/yvette/handlers/graphical/UnicodeThemeCharactersTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/handlers/graphical/UnicodeThemeCharactersTest.java
@@ -1,10 +1,12 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.yvette.handlers.graphical;
 
-import org.junit.jupiter.api.Test;
-
 import com.jparams.verifier.tostring.ToStringVerifier;
-
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
 
 public class UnicodeThemeCharactersTest {
     @Test


### PR DESCRIPTION
Applies [spotless](https://github.com/diffplug/spotless) license header and formatting steps.