### PR TITLE
Shallow integration of the prettier4j library for displaying diagnostic messages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,10 +3,7 @@ plugins {
     alias(libs.plugins.gradleJavaConventions)
 }
 
-repositories {
-    mavenCentral()
-    maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/") }
-}
+repositories { mavenCentral() }
 
 group = "com.opencastsoftware"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,10 @@ plugins {
     alias(libs.plugins.gradleJavaConventions)
 }
 
-repositories { mavenCentral() }
+repositories {
+    mavenCentral()
+    maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/") }
+}
 
 group = "com.opencastsoftware"
 
@@ -17,6 +20,7 @@ java {
 dependencies {
     implementation(libs.apacheCommonsLang)
     implementation(libs.apacheCommonsText)
+    implementation(libs.prettier4j)
     "graphicalReportsApi"(libs.jansi)
     testImplementation(libs.junitJupiter)
     testImplementation(libs.hamcrest)
@@ -70,9 +74,13 @@ mavenPublishing {
     }
 }
 
-tasks.withType<JavaCompile>() {
+tasks.compileJava {
     // Target Java 8
     options.release.set(8)
 }
 
-tasks.named<Test>("test") { useJUnitPlatform { includeEngines("junit-jupiter", "jqwik") } }
+testing {
+    suites {
+        val test by getting(JvmTestSuite::class) { useJUnitJupiter(libs.versions.junit) }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ jansi = "2.4.1"
 jacoco = "0.8.8"
 jqwik = "1.8.4"
 junit = "5.10.2"
-prettier4j = "0.3.0-12-e0132e7-SNAPSHOT"
+prettier4j = "0.3.1"
 toStringVerifier = "1.4.8"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ jansi = "2.4.1"
 jacoco = "0.8.8"
 jqwik = "1.8.4"
 junit = "5.10.2"
+prettier4j = "0.3.0-12-e0132e7-SNAPSHOT"
 toStringVerifier = "1.4.8"
 
 [libraries]
@@ -18,6 +19,7 @@ hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 jansi = { module = "org.fusesource.jansi:jansi", version.ref = "jansi" }
 jqwik = { module = "net.jqwik:jqwik", version.ref = "jqwik" }
 junitJupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+prettier4j = { module = "com.opencastsoftware:prettier4j", version.ref = "prettier4j" }
 toStringVerifier = { module = "com.jparams:to-string-verifier", version.ref = "toStringVerifier" }
 
 [plugins]

--- a/src/main/java/com/opencastsoftware/yvette/BasicDiagnostic.java
+++ b/src/main/java/com/opencastsoftware/yvette/BasicDiagnostic.java
@@ -1,8 +1,10 @@
 /*
- * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-FileCopyrightText:  © 2023-2024 Opencast Software Europe Ltd <https://opencastsoftware.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.opencastsoftware.yvette;
+
+import com.opencastsoftware.prettier4j.Doc;
 
 import java.net.URI;
 import java.util.Collection;
@@ -10,23 +12,24 @@ import java.util.Collection;
 public class BasicDiagnostic extends Diagnostic {
     public String code;
     public Severity severity;
-    public String help;
+    public Doc message;
+    public Doc help;
     public URI url;
     public SourceCode sourceCode;
     public Collection<LabelledRange> labels;
 
-    public BasicDiagnostic(String message) {
+    public BasicDiagnostic(Doc message) {
         this(null, Severity.Error, message, null, null, null, null);
     }
 
     public BasicDiagnostic(
-            String message,
+            Doc message,
             Throwable cause) {
         this(null, Severity.Error, message, cause, null, null, null, null);
     }
 
     public BasicDiagnostic(
-            String message,
+            Doc message,
             Throwable cause,
             URI url) {
         this(null, Severity.Error, message, cause, null, url, null, null);
@@ -35,23 +38,25 @@ public class BasicDiagnostic extends Diagnostic {
     public BasicDiagnostic(
             String code,
             Severity severity,
-            String message,
-            String help,
+            Doc message,
+            Doc help,
             URI url,
             SourceCode sourceCode,
             Collection<LabelledRange> labels) {
-        super(message);
+        super();
+        this.message = message;
     }
 
     public BasicDiagnostic(
             String code,
             Severity severity,
-            String message, Throwable cause,
-            String help,
+            Doc message, Throwable cause,
+            Doc help,
             URI url,
             SourceCode sourceCode,
             Collection<LabelledRange> labels) {
-        super(message, cause);
+        super(cause);
+        this.message = message;
     }
 
     @Override
@@ -65,12 +70,12 @@ public class BasicDiagnostic extends Diagnostic {
     }
 
     @Override
-    public String message() {
-        return getMessage();
+    public Doc message() {
+        return message;
     }
 
     @Override
-    public String help() {
+    public Doc help() {
         return help;
     }
 

--- a/src/main/java/com/opencastsoftware/yvette/Diagnostic.java
+++ b/src/main/java/com/opencastsoftware/yvette/Diagnostic.java
@@ -1,33 +1,33 @@
 /*
- * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-FileCopyrightText:  © 2023-2024 Opencast Software Europe Ltd <https://opencastsoftware.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.opencastsoftware.yvette;
+
+import com.opencastsoftware.prettier4j.Doc;
 
 import java.net.URI;
 import java.util.Collection;
 
 public abstract class Diagnostic extends RuntimeException {
     public abstract String code();
+    public abstract Doc message();
     public abstract Severity severity();
-    public abstract String help();
+    public abstract Doc help();
     public abstract URI url();
     public abstract SourceCode sourceCode();
     public abstract Collection<LabelledRange> labels();
 
-    public Diagnostic(String message) {
-        super(message);
+    public Diagnostic() {
+        super();
     }
 
     public Diagnostic(Throwable cause) {
         super(cause);
     }
 
-    public Diagnostic(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public String message() {
-        return getMessage();
+    @Override
+    public String getMessage() {
+        return message().render();
     }
 }

--- a/src/main/java/com/opencastsoftware/yvette/UncaughtExceptionHandler.java
+++ b/src/main/java/com/opencastsoftware/yvette/UncaughtExceptionHandler.java
@@ -1,9 +1,10 @@
 /*
- * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-FileCopyrightText:  © 2023-2024 Opencast Software Europe Ltd <https://opencastsoftware.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.opencastsoftware.yvette;
 
+import com.opencastsoftware.prettier4j.Doc;
 import com.opencastsoftware.yvette.handlers.ReportHandler;
 
 import java.io.IOException;
@@ -21,7 +22,7 @@ public class UncaughtExceptionHandler {
 
     public static Thread.UncaughtExceptionHandler create(ReportHandler handler, PrintStream output) {
         return (thread, exc) -> {
-            Diagnostic diagnostic = new BasicDiagnostic(exc.getMessage(), exc.getCause());
+            Diagnostic diagnostic = new BasicDiagnostic(Doc.text(exc.getMessage()), exc.getCause());
 
             output.format("Uncaught exception in thread %s: ", thread.getName());
 

--- a/src/main/java/com/opencastsoftware/yvette/handlers/graphical/GraphicalReportHandler.java
+++ b/src/main/java/com/opencastsoftware/yvette/handlers/graphical/GraphicalReportHandler.java
@@ -1,9 +1,10 @@
 /*
- * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-FileCopyrightText:  © 2023-2024 Opencast Software Europe Ltd <https://opencastsoftware.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.opencastsoftware.yvette.handlers.graphical;
 
+import com.opencastsoftware.prettier4j.RenderOptions;
 import com.opencastsoftware.yvette.*;
 import com.opencastsoftware.yvette.handlers.ReportHandler;
 import org.apache.commons.lang3.ObjectUtils;
@@ -29,6 +30,7 @@ public class GraphicalReportHandler implements ReportHandler {
     private final String footer;
     private final int contextLines;
     private final boolean renderCauseChain;
+    private final RenderOptions renderOptions;
 
     private static final Pattern ansiEscapePattern = Pattern.compile("\\u001B\\[[;\\d]*m");
 
@@ -40,6 +42,9 @@ public class GraphicalReportHandler implements ReportHandler {
         this.footer = footer;
         this.contextLines = contextLines;
         this.renderCauseChain = renderCauseChain;
+        this.renderOptions = RenderOptions.builder()
+                .emitAnsiEscapes(!theme.styles().equals(ThemeStyles.none()))
+                .build();
     }
 
     void renderHeader(Ansi ansi, Diagnostic diagnostic) {
@@ -116,7 +121,7 @@ public class GraphicalReportHandler implements ReportHandler {
             TextWrap.fill(
                     ansi, lineWidth,
                     initialIndent, subsequentIndent,
-                    diagnostic.message());
+                    diagnostic.message().render(renderOptions));
 
             ansi.a(System.lineSeparator());
 
@@ -553,7 +558,7 @@ public class GraphicalReportHandler implements ReportHandler {
             TextWrap.fill(
                     ansi, lineWidth,
                     initialIndent, subsequentIndent,
-                    diagnostic.help());
+                    diagnostic.help().render(renderOptions));
 
             ansi.a(System.lineSeparator());
         }
@@ -598,53 +603,29 @@ public class GraphicalReportHandler implements ReportHandler {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((linkStyle == null) ? 0 : linkStyle.hashCode());
-        result = prime * result + terminalWidth;
-        result = prime * result + ((theme == null) ? 0 : theme.hashCode());
-        result = prime * result + ((footer == null) ? 0 : footer.hashCode());
-        result = prime * result + contextLines;
-        result = prime * result + (renderCauseChain ? 1231 : 1237);
-        return result;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GraphicalReportHandler that = (GraphicalReportHandler) o;
+        return terminalWidth == that.terminalWidth && contextLines == that.contextLines && renderCauseChain == that.renderCauseChain && linkStyle == that.linkStyle && Objects.equals(theme, that.theme) && Objects.equals(footer, that.footer) && Objects.equals(renderOptions, that.renderOptions);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        GraphicalReportHandler other = (GraphicalReportHandler) obj;
-        if (linkStyle != other.linkStyle)
-            return false;
-        if (terminalWidth != other.terminalWidth)
-            return false;
-        if (theme == null) {
-            if (other.theme != null)
-                return false;
-        } else if (!theme.equals(other.theme))
-            return false;
-        if (footer == null) {
-            if (other.footer != null)
-                return false;
-        } else if (!footer.equals(other.footer))
-            return false;
-        if (contextLines != other.contextLines)
-            return false;
-        if (renderCauseChain != other.renderCauseChain)
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(linkStyle, terminalWidth, theme, footer, contextLines, renderCauseChain, renderOptions);
     }
 
     @Override
     public String toString() {
-        return "GraphicalReportHandler [linkStyle=" + linkStyle + ", terminalWidth=" + terminalWidth + ", theme="
-                + theme + ", footer=" + footer + ", contextLines=" + contextLines + ", renderCauseChain="
-                + renderCauseChain + "]";
+        return "GraphicalReportHandler[" +
+                "linkStyle=" + linkStyle +
+                ", terminalWidth=" + terminalWidth +
+                ", theme=" + theme +
+                ", footer='" + footer + '\'' +
+                ", contextLines=" + contextLines +
+                ", renderCauseChain=" + renderCauseChain +
+                ", renderOptions=" + renderOptions +
+                ']';
     }
 
     public static Builder builder() {

--- a/src/test/java/com/opencastsoftware/yvette/TestDiagnostic.java
+++ b/src/test/java/com/opencastsoftware/yvette/TestDiagnostic.java
@@ -1,34 +1,39 @@
 /*
- * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-FileCopyrightText:  © 2023-2024 Opencast Software Europe Ltd <https://opencastsoftware.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.opencastsoftware.yvette;
+
+import com.opencastsoftware.prettier4j.Doc;
 
 import java.net.URI;
 import java.util.List;
 
 public class TestDiagnostic extends Diagnostic {
     private final String code;
+    private final Doc message;
     private final Severity severity;
-    private final String help;
+    private final Doc help;
     private final URI url;
     private final SourceCode sourceCode;
     private final List<LabelledRange> labels;
 
-    public TestDiagnostic(String code, Severity severity, String message, String help, URI url, SourceCode sourceCode, List<LabelledRange> labels) {
-        super(message);
+    public TestDiagnostic(String code, Severity severity, Doc message, Doc help, URI url, SourceCode sourceCode, List<LabelledRange> labels) {
+        super();
         this.code = code;
         this.severity = severity;
+        this.message = message;
         this.help = help;
         this.url = url;
         this.sourceCode = sourceCode;
         this.labels = labels;
     }
 
-    public TestDiagnostic(String code, Severity severity, String message, Throwable cause, String help, URI url, SourceCode sourceCode, List<LabelledRange> labels) {
-        super(message, cause);
+    public TestDiagnostic(String code, Severity severity, Doc message, Throwable cause, Doc help, URI url, SourceCode sourceCode, List<LabelledRange> labels) {
+        super(cause);
         this.code = code;
         this.severity = severity;
+        this.message = message;
         this.help = help;
         this.url = url;
         this.sourceCode = sourceCode;
@@ -41,12 +46,17 @@ public class TestDiagnostic extends Diagnostic {
     }
 
     @Override
+    public Doc message() {
+        return message;
+    }
+
+    @Override
     public Severity severity() {
         return severity;
     }
 
     @Override
-    public String help() {
+    public Doc help() {
         return help;
     }
 

--- a/src/test/java/com/opencastsoftware/yvette/UncaughtExceptionHandlerTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/UncaughtExceptionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-FileCopyrightText:  © 2023-2024 Opencast Software Europe Ltd <https://opencastsoftware.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.opencastsoftware.yvette;
@@ -41,7 +41,7 @@ public class UncaughtExceptionHandlerTest {
             throwingThread.start();
             throwingThread.join();
 
-            String diagnosticOutput = baos.toString(StandardCharsets.UTF_8.name());
+            String diagnosticOutput = baos.toString(StandardCharsets.UTF_8);
 
             assertThat(
                     diagnosticOutput,
@@ -65,11 +65,8 @@ public class UncaughtExceptionHandlerTest {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         PrintStream printStream = new PrintStream(baos, true);
 
-        ReportHandler handler = new ReportHandler() {
-            @Override
-            public void display(Diagnostic diagnostic, Appendable output) throws IOException {
-                throw new IOException("Uh oh, this went very badly");
-            }
+        ReportHandler handler = (diagnostic, output) -> {
+            throw new IOException("Uh oh, this went very badly");
         };
 
         try {
@@ -84,7 +81,7 @@ public class UncaughtExceptionHandlerTest {
             throwingThread.start();
             throwingThread.join();
 
-            String diagnosticOutput = baos.toString(StandardCharsets.UTF_8.name());
+            String diagnosticOutput = baos.toString(StandardCharsets.UTF_8);
 
             assertThat(
                     diagnosticOutput,
@@ -142,7 +139,7 @@ public class UncaughtExceptionHandlerTest {
 
         assertThat("Executor should shut down", singleThread.awaitTermination(1, TimeUnit.SECONDS));
 
-        String diagnosticOutput = baos.toString(StandardCharsets.UTF_8.name());
+        String diagnosticOutput = baos.toString(StandardCharsets.UTF_8);
 
         assertThat(
                 diagnosticOutput,

--- a/src/test/java/com/opencastsoftware/yvette/arbitrary/DiagnosticSupplier.java
+++ b/src/test/java/com/opencastsoftware/yvette/arbitrary/DiagnosticSupplier.java
@@ -1,9 +1,10 @@
 /*
- * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-FileCopyrightText:  © 2023-2024 Opencast Software Europe Ltd <https://opencastsoftware.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.opencastsoftware.yvette.arbitrary;
 
+import com.opencastsoftware.prettier4j.Doc;
 import com.opencastsoftware.yvette.*;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
@@ -29,13 +30,13 @@ public class DiagnosticSupplier implements ArbitrarySupplier<Diagnostic> {
                         return Arbitraries.just(
                                 new TestDiagnostic(
                                         code, severity,
-                                        message, help, url,
+                                        Doc.text(message), Doc.text(help), url,
                                         sourceCode, Collections.emptyList()));
                     } else {
                         return labels(sourceCode).map(labels -> {
                             return new TestDiagnostic(
                                     code, severity,
-                                    message, help, url,
+                                    Doc.text(message), Doc.text(help), url,
                                     sourceCode, labels);
                         });
                     }
@@ -76,6 +77,7 @@ public class DiagnosticSupplier implements ArbitrarySupplier<Diagnostic> {
      */
     private Arbitrary<Position> position(StringSourceCode source) {
         String[] lines = source.source().split("\\r?\\n");
+        if (lines.length == 0) { System.out.println(source.source()); }
         return Arbitraries.integers()
                 .between(0, Math.max(0, lines.length - 1))
                 .flatMap(line -> {

--- a/src/test/java/com/opencastsoftware/yvette/handlers/graphical/GraphicalReportHandlerTest.java
+++ b/src/test/java/com/opencastsoftware/yvette/handlers/graphical/GraphicalReportHandlerTest.java
@@ -1,10 +1,11 @@
 /*
- * SPDX-FileCopyrightText:  Copyright 2023 Opencast Software Europe Ltd
+ * SPDX-FileCopyrightText:  © 2023-2024 Opencast Software Europe Ltd <https://opencastsoftware.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.opencastsoftware.yvette.handlers.graphical;
 
 import com.jparams.verifier.tostring.ToStringVerifier;
+import com.opencastsoftware.prettier4j.Doc;
 import com.opencastsoftware.yvette.*;
 import com.opencastsoftware.yvette.arbitrary.DiagnosticSupplier;
 import com.opencastsoftware.yvette.arbitrary.GraphicalThemeSupplier;
@@ -45,9 +46,9 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "Couldn't attach the source code to your diagnostic",
+                Doc.text("Couldn't attach the source code to your diagnostic"),
                 exc,
-                "try doing it better next time?",
+                Doc.text("try doing it better next time?"),
                 null,
                 null,
                 Collections.emptyList());
@@ -82,9 +83,9 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "Couldn't attach the source code to your diagnostic",
+                Doc.text("Couldn't attach the source code to your diagnostic"),
                 exc,
-                "try doing it better next time?",
+                Doc.text("try doing it better next time?"),
                 null,
                 null,
                 Collections.emptyList());
@@ -116,7 +117,7 @@ public class GraphicalReportHandlerTest {
                 Severity.Error,
                 null,
                 exc,
-                "try doing it better next time?",
+                Doc.text("try doing it better next time?"),
                 null,
                 null,
                 Collections.emptyList());
@@ -142,9 +143,9 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "Couldn't attach the source code to your diagnostic",
+                Doc.text("Couldn't attach the source code to your diagnostic"),
                 exc,
-                "try doing it better next time?",
+                Doc.text("try doing it better next time?"),
                 null,
                 null,
                 Collections.emptyList());
@@ -172,9 +173,9 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "Couldn't attach the source code to your diagnostic",
+                Doc.text("Couldn't attach the source code to your diagnostic"),
                 exc,
-                "try doing it better next time?",
+                Doc.text("try doing it better next time?"),
                 null,
                 null,
                 Collections.emptyList());
@@ -199,8 +200,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 null,
                 new StringSourceCode("BadFile.java", ""),
                 Collections.singletonList(
@@ -230,8 +231,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 null,
                 new StringSourceCode(null, ""),
                 Collections.singletonList(
@@ -261,8 +262,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 null,
                 new StringSourceCode(null, "source"),
                 Collections.singletonList(
@@ -295,7 +296,7 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 null,
                 Severity.Error,
-                "oops!",
+                Doc.text("oops!"),
                 null,
                 null,
                 new StringSourceCode("Issue.java", "source\ntext"),
@@ -328,7 +329,7 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 null,
                 Severity.Error,
-                "oops!",
+                Doc.text("oops!"),
                 null,
                 null,
                 new StringSourceCode("Issue.java", "source\ntext\nhere\nand\nsome\nmore"),
@@ -373,7 +374,7 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 null,
                 Severity.Error,
-                "oops!",
+                Doc.text("oops!"),
                 null,
                 null,
                 new StringSourceCode(null, "source\ntext"),
@@ -406,8 +407,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 null,
                 new StringSourceCode(
                         "BadFile.java", "source\n  👼🏼text\n    here"),
@@ -444,8 +445,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 null,
                 new StringSourceCode(
                         "BadFile.java", "source\n\t\ttext\n    here"),
@@ -482,8 +483,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 null,
                 new StringSourceCode(
                         "BadFile.java", "source\ntext =\ttext\n    here"),
@@ -519,8 +520,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 null,
                 new StringSourceCode("BadFile.java", "source\n  text\n    here"),
                 Collections.singletonList(
@@ -555,8 +556,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 null,
                 new StringSourceCode("BadFile.java", "source\n  text\n    here"),
                 Collections.singletonList(
@@ -590,8 +591,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 null,
                 new StringSourceCode("BadFile.java", "source\n  text\n    here"),
                 Collections.singletonList(
@@ -625,8 +626,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 null,
                 new StringSourceCode("BadFile.java", "source\n  text\n    here"),
                 Collections.singletonList(
@@ -661,8 +662,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 null,
                 new StringSourceCode("BadFile.java", "source\n  text\r\n    here"),
                 Collections.singletonList(
@@ -697,8 +698,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 null,
                 new StringSourceCode("BadFile.java", "source\n  text\n    here"),
                 Collections.singletonList(
@@ -733,8 +734,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 null,
                 new StringSourceCode("BadFile.java", "source\n  text\n    here"),
                 Collections.singletonList(
@@ -768,8 +769,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 null,
                 new StringSourceCode("BadFile.java", "source\ntext\n    here"),
                 Collections.singletonList(
@@ -804,8 +805,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 null,
                 new StringSourceCode("BadFile.java", "source\n  text text text text text\n    here"),
                 Arrays.asList(
@@ -851,8 +852,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 null,
                 new StringSourceCode("BadFile.java", "source\n  text text text\ttext text\n    here"),
                 Arrays.asList(
@@ -897,8 +898,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 null,
                 new StringSourceCode("BadFile.java", "source\n  text\n    here"),
                 Collections.singletonList(
@@ -932,8 +933,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 null,
                 new StringSourceCode("BadFile.java", "line1\nline2\nline3\nline4\nline5\n"),
                 Arrays.asList(
@@ -974,8 +975,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 null,
                 new StringSourceCode("BadFile.java", "line1\nline2\nline3\nline4\nline5\n"),
                 Arrays.asList(
@@ -1015,8 +1016,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 null,
                 new StringSourceCode("BadFile.java", "source\n  text\n    here\nmore here"),
                 Arrays.asList(
@@ -1056,8 +1057,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 URI.create("https://example.com"),
                 null,
                 Collections.emptyList());
@@ -1076,8 +1077,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 null,
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 URI.create("https://example.com"),
                 null,
                 Collections.emptyList());
@@ -1095,8 +1096,8 @@ public class GraphicalReportHandlerTest {
         Diagnostic err = new TestDiagnostic(
                 "oops-my-bad",
                 Severity.Error,
-                "oops!",
-                "try doing it better next time?",
+                Doc.text("oops!"),
+                Doc.text("try doing it better next time?"),
                 URI.create("https://example.com"),
                 null,
                 Collections.emptyList());


### PR DESCRIPTION
This PR does the minimum work necessary to allow a ReportHandler implementation based on prettier4j's `Doc` to be written.